### PR TITLE
Fix comment fingerprints

### DIFF
--- a/src/commands/comment.yml
+++ b/src/commands/comment.yml
@@ -59,7 +59,7 @@ steps:
             These warnings is probably about a change made to the base commit.
             If you rebase, the check may be successful.
           </p>
-          <details>\(map("<blockquote>\(.body)</blockquote>")|join(""))</details>
+          <details>\(sort|map("<blockquote>\(.body)</blockquote>")|join(""))</details>
         </article>
         EOT
         )\"}"
@@ -75,8 +75,13 @@ steps:
               echo "${RELATIVE_PATH#./}"
             }
 
+            function fingerprint_comment {
+              tee /dev/stderr | jq -cM 'del(.commit_id)' | sha1sum
+            }
+
             function check_comment_fingerprints {
-              grep -q "$(jq -cM 'del(.commit_id)' | sha1sum)" <"$1"
+              SHA1="$(fingerprint_comment)"
+              { tee /dev/stderr | grep -qF "$SHA1" ; } <"$1"
             }
 
             ANALYSIS_RESULTS_PATH="${ANALYSIS_RESULTS_PATH:-${DSCAR_ANALYSIS_RESULTS_PATH:-/tmp/dscar/analysis-results}}"
@@ -153,7 +158,7 @@ steps:
                       then
                         if curl -SsfL "${REQUEST_HEADERS[@]}" --data-binary "@${REQUEST_BODY}" "${COMMENT_URL}"
                         then
-                          { jq -cM 'del(.commit_id)' | sha1sum ; } < "${REQUEST_BODY}" >> "${COMMENT_FINGERPRINTS}"
+                          fingerprint_comment < "${REQUEST_BODY}" >> "${COMMENT_FINGERPRINTS}"
                         else
                           jq -cM 'del(.commit_id)' < "${REQUEST_BODY}" >> "${MESSAGES_THAT_COULD_NOT_BE_COMMENTED}"
                         fi
@@ -170,14 +175,14 @@ steps:
               mkdir -p "$(dirname "${COMMENT_FINGERPRINTS}")"
               touch "${COMMENT_FINGERPRINTS}"
 
-              if [ $(jq -srM 'length' < "${MESSAGES_THAT_COULD_NOT_BE_COMMENTED}") -gt 0 ]
+              if [ $(jq -srcM 'length' < "${MESSAGES_THAT_COULD_NOT_BE_COMMENTED}") -gt 0 ]
               then
                 REQUEST_BODY="$(mktemp)"
-                jq -srM "${FILTER}" < "${MESSAGES_THAT_COULD_NOT_BE_COMMENTED}" > "${REQUEST_BODY}"
+                jq -srcM "${FILTER}" < "${MESSAGES_THAT_COULD_NOT_BE_COMMENTED}" | tee /dev/stderr > "${REQUEST_BODY}"
                 if ! check_comment_fingerprints "${COMMENT_FINGERPRINTS}" < "${REQUEST_BODY}"
                 then
                   curl -SsfL "${REQUEST_HEADERS[@]}" --data-binary "@${REQUEST_BODY}" "${PR_COMMENT_URL}"
-                  sha1sum < "${REQUEST_BODY}" >> "${COMMENT_FINGERPRINTS}"
+                  fingerprint_comment < "${REQUEST_BODY}" >> "${COMMENT_FINGERPRINTS}"
                 else
                   echo 'This warning has been commented.' >&2
                 fi


### PR DESCRIPTION
This is a fix for comment fingerprints that failed to comment on reviews.

- Sort the comments because the order of the comments was unspecified
- Create a function to fingerprint comments
- Align `jq` command options