### PR TITLE
Refine analysis result

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             COMMENT_FINGERPRINTS_PATH="/tmp/dscar/comment-fingerprints/.MESSAGES_THAT_COULD_NOT_BE_COMMENTED"
             COMMENT_FINGERPRINTS="${COMMENT_FINGERPRINTS_PATH}/$(echo "${CIRCLE_PULL_REQUEST}" | sha1sum | cut -c1-40)"
             mkdir -p "$(dirname "${COMMENT_FINGERPRINTS}")"
-            echo 'b84eeea8caeb3517e9474b7ae81646846a092ad2  -' > "${COMMENT_FINGERPRINTS}"
+            echo '172a6b294407e6b80b2f6bb270e951c7c19960a9  -' > "${COMMENT_FINGERPRINTS}"
       - dscar/comment:
           when: on_success
   integration-test-3:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,41 @@ jobs:
             test -e "DELTA-analysis-result.xml"
             sudo apt-get install xmlstarlet
             xmlstarlet sel -t -m '//error' -n >/dev/null < "DELTA-analysis-result.xml"
+  integration-test-6:
+    executor:
+      <<: *dscar-default-executor
+    steps:
+      - checkout
+      - run:
+          name: setup
+          command: |
+            git remote update
+            BASE=$(git rev-parse v1.0.0)
+            HEAD=$(git rev-parse v1.0.2)
+            RESULT_PATH="${DSCAR_ANALYSIS_RESULTS_PATH}/true/0/${HEAD}-analysis-result.xml"
+            mkdir -p "$(dirname "${RESULT_PATH}")"
+            cat \<<-EOT > "$RESULT_PATH"
+            <checkstyle>
+              <file name="${PWD}/src/commands/analyze.yml">
+                <error source="foo" message="hello" line="115" column="0" severity="error" />
+                <error source="bar" message="world" line="116" column="0" severity="error" />
+                <error source="baz" message="abcde" line="114" column="0" severity="error" />
+              </file>
+            </checkstyle>
+            EOT
+            declare -Ax DSCAR_COMMIT_RANGES=( [0]="${BASE}..${HEAD}" )
+            echo "$(declare -p DSCAR_COMMIT_RANGES)" >> $BASH_ENV
+      - dscar/refine-analysis-result
+      - run:
+          name: evaluate
+          command: |
+            set -x
+            DELTA=b6589fc6ab0dc82cf12099d1c2d40ab994e8410c
+            RESULT_PATH="${DSCAR_ANALYSIS_RESULTS_PATH}/true/0/${DELTA}-DELTA-analysis-result.xml"
+            test -e "$RESULT_PATH"
+            sudo apt-get install xmlstarlet
+            test $(xmlstarlet sel -t -m '//error' -n < "$RESULT_PATH" | wc -l) -eq 1
+            xmlstarlet sel -t -m "//file[@name='${PWD}/src/commands/analyze.yml']/error[@line='115']" -c '.' -n < "$RESULT_PATH"
 
 workflows:
   lint_pack-validate_publish-dev:
@@ -200,4 +235,5 @@ workflows:
       - integration-test-3
       - integration-test-4
       - integration-test-5
+      - integration-test-6
     when: << pipeline.parameters.run-integration-tests >>

--- a/Makefile
+++ b/Makefile
@@ -57,5 +57,15 @@ integration-test-4: .circleci/compiled-config.yml
 integration-test-5: .circleci/compiled-config.yml
 	circleci local execute -c $< --job $@
 
+.PHONY: integration-test-6
+integration-test-6: .circleci/compiled-config.yml
+	circleci local execute -c $< --job $@
+
 .PHONY: integration-test
-integration-test: integration-test-1 integration-test-2 integration-test-3 integration-test-4 integration-test-5
+integration-test: \
+	integration-test-1 \
+	integration-test-2 \
+	integration-test-3 \
+	integration-test-4 \
+	integration-test-5 \
+	integration-test-6

--- a/src/commands/execute-and-evaluate.yml
+++ b/src/commands/execute-and-evaluate.yml
@@ -8,11 +8,6 @@ parameters:
     type: steps
     default:
       - analyze
-  calculate:
-    description: Specify the steps for calculating the difference
-    type: steps
-    default:
-      - calculate
   test-results-path:
     description: Specify the value of the path parameter in the store_test_results step if you need to change it
     type: string
@@ -31,10 +26,14 @@ steps:
   - declare-commit-ranges:
       circle_compare_url-path: << parameters.circle_compare_url-path >>
       vcs-api-token: << parameters.vcs-api-token >>
+  - run:
+      name: declare -x DSCAR_ANALYSIS_TARGET
+      command: |
+        set -x
+        declare -x DSCAR_ANALYSIS_TARGET=head
+        echo "$(declare -p DSCAR_ANALYSIS_TARGET)" >> $BASH_ENV
   - steps: << parameters.analyze >>
-  # steps to calculate the difference
-  - set-analysis-result-paths
-  - steps: << parameters.calculate >>
+  - refine-analysis-result
   - restore_comment-fingerprints
   - evaluate:
       pattern: &pattern '.*/([0-9]+-|)[0-9a-f]+-DELTA-analysis-result.xml$'

--- a/src/commands/refine-analysis-result.yml
+++ b/src/commands/refine-analysis-result.yml
@@ -50,7 +50,7 @@ steps:
             const name = node.getAttribute('name');
             Array.from(node.getElementsByTagName('error')).forEach(node => {
               const position = Number(node.getAttribute('line'));
-              const ranges = hunks[path.normalize(name)] || [];
+              const ranges = hunks[path.relative(process.env.PWD, name)] || [];
               for (const [start, end] of ranges) if (position >= start && position <= end) return;
               node.parentNode.removeChild(node);
             });

--- a/src/commands/refine-analysis-result.yml
+++ b/src/commands/refine-analysis-result.yml
@@ -1,0 +1,87 @@
+description:
+parameters:
+  analysis-results-path:
+    description: "Specify the path to save the analysis results if you need to change it (default: /tmp/dscar/analysis-results)"
+    type: string
+    default: ""
+steps:
+  - run:
+      name: Refine analysis result
+      environment:
+        ANALYSIS_RESULTS_PATH: << parameters.analysis-results-path >>
+      command: |
+        set -x
+
+        ANALYSIS_RESULTS_PATH="${ANALYSIS_RESULTS_PATH:-${DSCAR_ANALYSIS_RESULTS_PATH:-/tmp/dscar/analysis-results}}"
+
+        sudo npm install --global xmldom
+
+        SCRIPT="$(mktemp)"
+        cat > "$SCRIPT" \<<-"EOT"
+        const fs = require('fs');
+        const path = require('path');
+        const util = require('util');
+        const xmldom = require('xmldom');
+
+        const parse = text => {
+          const [start, lines = 1] = text.split(',').map(Number).map(Math.abs);
+          return [start, start + lines - 1];
+        };
+
+        const hunks = JSON.parse(fs.readFileSync(process.argv[2]))
+          .map(([name, left, right]) => ({ name, left: parse(left), right: parse(right) }))
+          .reduce((hunks, hunk) => {
+            const ranges = hunks[hunk.name] || [];
+            hunks[hunk.name] = ranges.concat([hunk.right]);
+            return hunks;
+          }, {});
+
+        new Promise((resolve, reject) => {
+          const chunks = [];
+          process.stdin
+            .on('data', (chunk) => chunks.push(chunk))
+            .on('end', () => resolve(Buffer.concat(chunks)))
+            .on('error', reject);
+        }).then(buffer => {
+          const xml = new util.TextDecoder('UTF-8').decode(buffer);
+          return new xmldom.DOMParser().parseFromString(xml, 'application/xml');
+        }).then(document => {
+          Array.from(document.getElementsByTagName('file')).forEach(node => {
+            const name = node.getAttribute('name');
+            Array.from(node.getElementsByTagName('error')).forEach(node => {
+              const position = Number(node.getAttribute('line'));
+              const ranges = hunks[path.normalize(name)] || [];
+              for (const [start, end] of ranges) if (position >= start && position <= end) return;
+              node.parentNode.removeChild(node);
+            });
+          });
+          const xml = new xmldom.XMLSerializer().serializeToString(document);
+          console.log(xml);
+        }).catch(e => { console.error(e); process.exit(1); });
+        EOT
+
+        for KEY in "${!DSCAR_COMMIT_RANGES[@]}"
+        do
+          COMMIT_RANGE="${DSCAR_COMMIT_RANGES[$KEY]}"
+          COMMITS=( $(echo ${COMMIT_RANGE} | tr -s '.' '\t' ) )
+          BASE=${COMMITS[0]}
+          HEAD=${COMMITS[1]}
+          DELTA=$(echo -n "$KEY" | sha1sum | cut -d' ' -f1)
+          TRIPLE_DOT="${BASE}...${HEAD}"
+
+          HUNKS_METADATA="$(mktemp)"
+          git diff --name-only $TRIPLE_DOT |
+          while read -r NAME
+          do
+            git --no-pager diff -U0 $TRIPLE_DOT -- $NAME |
+            awk -v name="$NAME" 'BEGIN { OFS = "\t" } /^@@ / { print name, $2, $3; }'
+          done | jq -scMR 'split("\n") | map(select(. != "") | split("\t"))' > "$HUNKS_METADATA"
+
+          find "$ANALYSIS_RESULTS_PATH" -type f -regextype posix-extended -regex ".*/([0-9]+-|)${HEAD}-analysis-result.xml$" |
+          while read -r RESULT_PATH
+          do
+            REFINE_RESULT_PATH=$(echo "$RESULT_PATH" | sed -e "s/\b${HEAD}\b/${DELTA}-DELTA/")
+            NODE_PATH="$(npm -g prefix)/lib/node_modules" node "$SCRIPT" "$HUNKS_METADATA" < "$RESULT_PATH" |
+            tee /dev/stderr > "$REFINE_RESULT_PATH"
+          done
+        done

--- a/src/commands/refine-analysis-result.yml
+++ b/src/commands/refine-analysis-result.yml
@@ -1,4 +1,4 @@
-description:
+description: Refine analysis result
 parameters:
   analysis-results-path:
     description: "Specify the path to save the analysis results if you need to change it (default: /tmp/dscar/analysis-results)"

--- a/src/commands/restore_comment-fingerprints.yml
+++ b/src/commands/restore_comment-fingerprints.yml
@@ -1,4 +1,4 @@
-description:
+description: Restore comment fingerprints from cache
 steps:
   - restore_cache:
       name: Restoring comment fingerprints cache

--- a/src/commands/save_comment-fingerprints.yml
+++ b/src/commands/save_comment-fingerprints.yml
@@ -1,4 +1,4 @@
-description:
+description: Save comment fingerprints to cache
 parameters:
   when:
     description: "Specify when to enable or disable the step. Takes the following values: always, on_success, on_fail (default: on_fail)"

--- a/src/jobs/execute.yml
+++ b/src/jobs/execute.yml
@@ -8,16 +8,15 @@ parameters:
     description: Amount of CPU and RAM allocated to each container in a job.
     type: string
     default: small
+  parallelism:
+    description: If parallelism is set to N > 1, then N independent executors will be set up and each will run the steps of that job in parallel.
+    type: integer
+    default: 1
   analyze:
     description: Specify analysis steps
     type: steps
     default:
       - analyze
-  calculate:
-    description: Specify the steps for calculating the difference
-    type: steps
-    default:
-      - calculate
   test-results-path:
     description: Specify the value of the path parameter in the store_test_results step if you need to change it
     type: string
@@ -32,11 +31,10 @@ parameters:
     default: ""
 executor: << parameters.executor >>
 resource_class: << parameters.resource_class >>
-parallelism: 1
+parallelism: << parameters.parallelism >>
 steps:
   - execute-and-evaluate:
       analyze: << parameters.analyze >>
-      calculate: << parameters.calculate >>
       test-results-path: << parameters.test-results-path >>
       vcs-api-token: << parameters.vcs-api-token >>
       circle_compare_url-path: << parameters.circle_compare_url-path >>


### PR DESCRIPTION
Change the method of obtaining analysis results for differences.

In the conventional method, the base branch and the head branch are analyzed separately, and the difference set of the analysis results is calculated.

The new method analyzes only the head branch and narrows down the analysis result by the difference between the head branch and the base branch.